### PR TITLE
Goldenrod UG B2F grunts have swapped position

### DIFF
--- a/locations/dungeons.json
+++ b/locations/dungeons.json
@@ -2670,12 +2670,12 @@
                         "name": "Goldenrod UG B2F - Grunt 3"
                     },
                     {
-                        "ref": "JohtoKanto/Goldenrod Underground/B2F - Grunt 1",
-                        "name": "Goldenrod UG B2F - Grunt 1"
-                    },
-                    {
                         "ref": "JohtoKanto/Goldenrod Underground/B2F - Grunt 2",
                         "name": "Goldenrod UG B2F - Grunt 2"
+                    },
+                    {
+                        "ref": "JohtoKanto/Goldenrod Underground/B2F - Grunt 1",
+                        "name": "Goldenrod UG B2F - Grunt 1"
                     },
                     {
                         "ref": "JohtoKanto/Goldenrod Underground/B2F - West Hidden Item",
@@ -3089,7 +3089,7 @@
                 "name": "",
                 "sections": [
                     {
-                        "ref": "JohtoKanto/Goldenrod Underground/B2F - Grunt 1"
+                        "ref": "JohtoKanto/Goldenrod Underground/B2F - Grunt 2"
                     }
                 ],
                 "map_locations": [
@@ -3104,7 +3104,7 @@
                 "name": "",
                 "sections": [
                     {
-                        "ref": "JohtoKanto/Goldenrod Underground/B2F - Grunt 2"
+                        "ref": "JohtoKanto/Goldenrod Underground/B2F - Grunt 3"
                     }
                 ],
                 "map_locations": [
@@ -3149,7 +3149,7 @@
                 "name": "",
                 "sections": [
                     {
-                        "ref": "JohtoKanto/Goldenrod Underground/B2F - Grunt 3"
+                        "ref": "JohtoKanto/Goldenrod Underground/B2F - Grunt 1"
                     }
                 ],
                 "map_locations": [


### PR DESCRIPTION
apworld 4.0.9 will have the grunts as 3, 2, 1
Currently are 2, 1, 3