### PR TITLE
Update access rules for JohtoKanto Route 46

### DIFF
--- a/locations/locations.json
+++ b/locations/locations.json
@@ -8669,7 +8669,7 @@
                             "show_items, grasssanity_single"
                         ],
                         "access_rules": [
-                            "$can_cut_johto"
+                            "@JohtoKanto/Route 46/Below Ledge, $can_cut_johto"
                         ]
                     },
                     {


### PR DESCRIPTION
made `access_rules` for "Single Grass" the same as "Grass" for Route 46