### PR TITLE
Fixed a couple Celadon Issues

### DIFF
--- a/locations/dungeons.json
+++ b/locations/dungeons.json
@@ -803,7 +803,7 @@
                     },
                     {   
                         "ref": "JohtoKanto/Celadon City/Leftovers from Cafe"
-                        "name": "Celason City - Leftovers from Cafe"
+                        "name": "Celadon City - Leftovers from Cafe"
                     }
                 ],
                 "map_locations": [


### PR DESCRIPTION
Fixed Manager's Suite Sign not showing on Celadon City map. Fixed Eatathon Contest Poster sharing square with Leftovers in the trash can. Also had to fix my own typo as you can see. 