### PR TITLE
Correct name and reorder

### DIFF
--- a/locations/dungeons.json
+++ b/locations/dungeons.json
@@ -1017,7 +1017,7 @@
                     {
                         "ref": "JohtoKanto/Cianwood City/Gym - Leader Chuck",
                         "name": "Gym - Leader Chuck"
-                    }
+                    },
                     {
                         "ref": "JohtoKanto/Cianwood City/Gym - Storm Badge from Chuck",
                         "name": "Gym - Storm Badge from Chuck"


### PR DESCRIPTION
Corrected name for Cianwood Gym on city map, also reordered the references to closer match other Gyms