### PR TITLE
Fix reference path for Leader Blue in dungeons.json

### DIFF
--- a/locations/dungeons.json
+++ b/locations/dungeons.json
@@ -15271,7 +15271,7 @@
                         "name": "Beat Blue"
                     },
                     {
-                        "ref": "JohtoKanto//Gym - Leader Blue",
+                        "ref": "JohtoKanto/Viridian City/Gym - Leader Blue",
                         "name": "Leader Blue"
                     },
                     {


### PR DESCRIPTION
found something... don't know when it happened but here it is fixed