### PR TITLE
Require Pokedex for Lake of Rage Magikarp Prize

### DIFF
--- a/locations/locations.json
+++ b/locations/locations.json
@@ -10293,7 +10293,7 @@
                             "show_items, randomize_pokemon_requests_true"
                         ],
                         "access_rules": [
-                            "EVENT_CLEARED_ROCKET_HIDEOUT"
+                            "EVENT_CLEARED_ROCKET_HIDEOUT, $pokedex"
                         ],
                         "chest_unopened_img": "images/gift/blue_fishing_guru.png",
                         "chest_opened_img": "images/gift/blue_fishing_guru_open.png"


### PR DESCRIPTION
## Summary
The world-side rule for `Lake of Rage - Magikarp Prize` requires the Pokedex (rules.py), matching the other PokemonRequest locations (Beverly's Nugget, Derek's Nugget, Tiffany's Pink Bow), but the tracker's access rule only checked `EVENT_CLEARED_ROCKET_HIDEOUT`. Add the missing `\$pokedex` check so the location only goes in-logic once the player has the Pokedex.