### PR TITLE
Fix National Park gatehouse Unown sign logic relative to bicycle roadblock

### DIFF
--- a/locations/locations.json
+++ b/locations/locations.json
@@ -5191,7 +5191,7 @@
                             "show_signs, goal_unown"
                         ],
                         "access_rules": [
-                            "^$unownsign|Route35BugCatchingContestExplanationSign, @JohtoKanto/Goldenrod City"
+                            "^$unownsign|Route35BugCatchingContestExplanationSign, @JohtoKanto/Goldenrod City, $nationalpark"
                         ]
                     },
                     {
@@ -5334,7 +5334,7 @@
                             "show_signs, goal_unown"
                         ],
                         "access_rules": [
-                            "^$unownsign|Route36BugCatchingContextExplanationSign, @JohtoKanto/National Park/Park"
+                            "^$unownsign|Route36BugCatchingContextExplanationSign, @JohtoKanto/Route 36/Left"
                         ]
                     },
                     {


### PR DESCRIPTION
## Summary

The two National Park gatehouse Unown signs were on the wrong side of the bicycle roadblock in logic. The roadblock guard sits on the Goldenrod/Route 35 side of the park, so the two gatehouse signs are on opposite sides of it:

- **Route 35 Gate Bug Catching Contest Explanation Sign** — behind the roadblock. Was reachable from `@JohtoKanto/Goldenrod City` without the bicycle; now requires `$nationalpark` (bicycle / vanilla access), consistent with the park region's own Goldenrod-side access rule.
- **Route 36 Gate Bug Catching Contest Explanation Sign** — before the roadblock. Was gated behind `@JohtoKanto/National Park/Park` (which requires the bicycle); now reachable from `@JohtoKanto/Route 36/Left` without the bicycle.

## Notes

- `$nationalpark` = `has("national_park_vanilla") or has("BICYCLE")` (`scripts/logic/logic.lua`).
- `Route 36/Left` is the region the National Park connects to on the Route 36 side, and it is reachable without the bicycle (e.g. via the Goldenrod + Cut path), so the south sign now clears without the bike.
- Inside-park signs (Battle Notice, Relaxation Square, Trainer Tips) remain `$nationalpark`-gated and are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)